### PR TITLE
feat: implement show product api

### DIFF
--- a/routers/product.py
+++ b/routers/product.py
@@ -1,9 +1,8 @@
 from flask import Blueprint, request
-from controller.product import create, read, delete, update_multi
+from controller.product import create, read, delete, update_multi, show
 from controller.access import check_permission
 
 products = Blueprint("products", __name__)
-
 
 @products.route("", methods=["POST"])
 @check_permission('create')
@@ -34,3 +33,9 @@ def delete_product():
     data = request.get_json()
 
     return delete(data)
+
+@products.route("/<int:product_id>", methods=["GET"])
+@check_permission('read')
+def show_product(product_id):
+
+    return show(product_id)

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -871,6 +871,39 @@ paths:
                           type: integer
                           example: 1
 
+  /product/{product_id}:
+    get:
+      tags:
+        - Products
+      summary: Get a product
+      description: Retrieve a specific product by ID.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          required: true
+          name: product_id
+          description: ID of the product to retrieve
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 200
+                  msg:
+                    type: string
+                    example: Success
+                  data:
+                    $ref: "#/components/schemas/Product"
+
+
   /product/{series_id}/search:
     post:
       tags:
@@ -1184,3 +1217,29 @@ components:
                 type: integer
               isRequired:
                 type: integer
+
+    Product:
+      type: object
+      properties:
+        itemId:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: Product 1
+        seriesId:
+          type: integer
+          example: 1
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/Field'
+    Field:
+      type: object
+      properties:
+        key:
+          type: string
+          example: "1"
+        value:
+          type: string
+          example: Field Value


### PR DESCRIPTION
In this PR, I have added new endpoints and schema definitions to our Flask application, specifically for product management. Here's a summary of the changes:

- **Endpoints:**
  - `GET /product/:productId`: Endpoint to show product details.

- **Schema definitions:**
  - Added `Product` and `Field` schema definitions in OpenAPI spec.

This update provides the necessary API for showing for product. I've tested the new endpoints and they're working as expected.

Please review the changes and let me know if there are any suggestions or concerns.